### PR TITLE
Added publish instruction

### DIFF
--- a/src/yaml/configuration-parser.rb
+++ b/src/yaml/configuration-parser.rb
@@ -27,6 +27,7 @@ require_relative 'collection-instruction'
 require_relative 'copy-instruction'
 require_relative 'install-instruction'
 require_relative 'nop-instruction'
+require_relative 'publish-instruction'
 require_relative 'run-instruction'
 
 
@@ -100,6 +101,8 @@ class YamlConfigurationParser
 				instruction.append parse_base(value)
 			elsif 'install' == key
 				instruction.append parse_install(value)
+			elsif 'publish' == key
+				instruction.append parse_publish(value)
 			else
 				raise "Unsupported key \`#{key}' in YAML hash node \`#{hash}'"
 			end
@@ -124,6 +127,13 @@ class YamlConfigurationParser
 
 
 
+	# @return {@link YamlPublishInstruction}
+	def self.parse_publish(packages)
+		return YamlPublishInstruction.new packages
+	end
+
+
+
 
 
 	private_class_method :parse_node
@@ -131,6 +141,7 @@ class YamlConfigurationParser
 	private_class_method :parse_hash
 	private_class_method :parse_base
 	private_class_method :parse_install
+	private_class_method :parse_publish
 
 end
 

--- a/src/yaml/publish-instruction.rb
+++ b/src/yaml/publish-instruction.rb
@@ -1,0 +1,115 @@
+# Copyright (c) 2017 github/ooxi
+#     https://github.com/ooxi/mini-cross
+#
+# This software is provided 'as-is', without any express or implied warranty. In
+# no event will the authors be held liable for any damages arising from the use
+# of this software.
+#
+# Permission is granted to anyone to use this software for any purpose,
+# including commercial applications, and to alter it and redistribute it freely,
+# subject to the following restrictions:
+#
+#  1. The origin of this software must not be misrepresented; you must not claim
+#     that you wrote the original software. If you use this software in a product,
+#     an acknowledgment in the product documentation would be appreciated but is
+#     not required.
+#
+#  2. Altered source versions must be plainly marked as such, and must not be
+#     misrepresented as being the original software.
+#
+#  3. This notice may not be removed or altered from any source distribution.
+
+require_relative '../docker/base'
+require_relative 'instruction'
+
+
+
+# Instruct to publish a set of port forwardings
+class YamlPublishInstruction < YamlInstruction
+
+
+	def initialize(publications)
+
+		if not publications.kind_of? Array
+			raise "Expected array of publication descriptions, got \`#{publications}'"
+		end
+
+		@publications = publications.collect{|publication|
+			YamlPublishInstruction.parse_publication publication
+		}
+	end
+
+
+
+	def apply_to(docker_context)
+		raise '`docker-context\' should be of type BaseDockerContext' unless docker_context.kind_of?(BaseDockerContext)
+
+		@publications.each{|publication|
+			docker_context.run.publish publication.ip, publication.host_port, publication.container_port
+		}
+	end
+
+
+
+
+	# format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort
+	#
+	# @see https://docs.docker.com/engine/reference/run/#expose-incoming-ports
+	def self.parse_publication(publication)
+		if not publication.kind_of? String
+			raise "\`publication' must be of type \`String' but \`#{publication}' is of type \`#{publication.class}'"
+		end
+
+		# @warning Does not work with IPv6 host IP! But docker does
+		#     neither…
+		parts = publication.split(':')
+
+		if (3 == parts.length)
+			return YamlPublishInstructionPublication.new parts[0], parts[1], parts[2]
+		elsif (2 == parts.length)
+			return YamlPublishInstructionPublication.new '', parts[0], parts[1]
+		elsif (1 == parts.length)
+			return YamlPublishInstructionPublication.new '', '', parts[0]
+		else
+			raise "\`publication' must have a format like ip:host_port:container_port | ip::container_port | hostPort:container_port | container_port but \`#{publication}' does not"
+		end
+	end
+
+end
+
+
+
+
+
+class YamlPublishInstructionPublication
+
+	def initialize(ip, host_port, container_port)
+		@ip = if ip.empty?
+			nil
+		else
+			ip
+		end
+
+		@host_port = if host_port.empty?
+			nil
+		else
+			Integer(host_port)
+		end
+
+		@container_port = Integer(container_port)
+	end
+
+
+	def ip
+		return @ip
+	end
+
+	def host_port
+		return @host_port
+	end
+
+	def container_port
+		return @container_port
+	end
+end
+

--- a/test/tc-docker-docker-run-arguments.rb
+++ b/test/tc-docker-docker-run-arguments.rb
@@ -44,6 +44,38 @@ class TestDockerfile < Test::Unit::TestCase
 	end
 
 
+	def test_DockerPublishArgument_IpHostContainer
+		publication = DockerPublishArgument.new '127.0.0.1', 8080, 80
+		args = publication.to_args
+
+		assert_equal(['-p', '127.0.0.1:8080:80'], args, 'Wrong docker publish arguments')
+	end
+
+
+	def test_DockerPublishArgument_IpContainer
+		publication = DockerPublishArgument.new '127.0.0.1', nil, 80
+		args = publication.to_args
+
+		assert_equal(['-p', '127.0.0.1::80'], args, 'Wrong docker publish arguments')
+	end
+
+
+	def test_DockerPublishArgument_HostContainer
+		publication = DockerPublishArgument.new nil, 8080, 80
+		args = publication.to_args
+
+		assert_equal(['-p', '8080:80'], args, 'Wrong docker publish arguments')
+	end
+
+
+	def test_DockerPublishArgument_Container
+		publication = DockerPublishArgument.new nil, nil, 80
+		args = publication.to_args
+
+		assert_equal(['-p', '80'], args, 'Wrong docker publish arguments')
+	end
+
+
 	def test_DockerUserArgument_NoUser
 		user = DockerUserArgument.new nil
 		args = user.to_args

--- a/test/tc-yaml-publish-instruction.rb
+++ b/test/tc-yaml-publish-instruction.rb
@@ -1,0 +1,71 @@
+# Copyright (c) 2017 github/ooxi
+#     https://github.com/ooxi/mini-cross
+#
+# This software is provided 'as-is', without any express or implied warranty. In
+# no event will the authors be held liable for any damages arising from the use
+# of this software.
+#
+# Permission is granted to anyone to use this software for any purpose,
+# including commercial applications, and to alter it and redistribute it freely,
+# subject to the following restrictions:
+#
+#  1. The origin of this software must not be misrepresented; you must not claim
+#     that you wrote the original software. If you use this software in a product,
+#     an acknowledgment in the product documentation would be appreciated but is
+#     not required.
+#
+#  2. Altered source versions must be plainly marked as such, and must not be
+#     misrepresented as being the original software.
+#
+#  3. This notice may not be removed or altered from any source distribution.
+
+require 'test/unit'
+
+require_relative '../src/yaml/publish-instruction'
+
+
+
+class TestYamlPublishInstruction < Test::Unit::TestCase
+
+
+	def test_ParseIpHostContainer
+		pub = YamlPublishInstruction.parse_publication '127.0.0.1:8080:80'
+
+		assert(pub.kind_of?(YamlPublishInstructionPublication), 'publication should be of kind YamlPublishInstructionPublication')
+		assert_equal('127.0.0.1', pub.ip, 'Publication has wrong ip')
+		assert_equal(8080, pub.host_port, 'Publication has wrong host port')
+		assert_equal(80, pub.container_port, 'Publication has wrong container port')
+	end
+
+
+	def test_ParseIpContainer
+		pub = YamlPublishInstruction.parse_publication '127.0.0.1::80'
+
+		assert(pub.kind_of?(YamlPublishInstructionPublication), 'publication should be of kind YamlPublishInstructionPublication')
+		assert_equal('127.0.0.1', pub.ip, 'Publication has wrong ip')
+		assert_equal(nil, pub.host_port, 'Publication has wrong host port')
+		assert_equal(80, pub.container_port, 'Publication has wrong container port')
+	end
+
+
+	def test_ParseHostContainer
+		pub = YamlPublishInstruction.parse_publication '8080:80'
+
+		assert(pub.kind_of?(YamlPublishInstructionPublication), 'publication should be of kind YamlPublishInstructionPublication')
+		assert_equal(nil, pub.ip, 'Publication has wrong ip')
+		assert_equal(8080, pub.host_port, 'Publication has wrong host port')
+		assert_equal(80, pub.container_port, 'Publication has wrong container port')
+	end
+
+
+
+	def test_ParseContainer
+		pub = YamlPublishInstruction.parse_publication '80'
+
+		assert(pub.kind_of?(YamlPublishInstructionPublication), 'publication should be of kind YamlPublishInstructionPublication')
+		assert_equal(nil, pub.ip, 'Publication has wrong ip')
+		assert_equal(nil, pub.host_port, 'Publication has wrong host port')
+		assert_equal(80, pub.container_port, 'Publication has wrong container port')
+	end
+end
+

--- a/test/tc.rb
+++ b/test/tc.rb
@@ -34,4 +34,5 @@ require_relative 'tc-shell'
 require_relative 'tc-yaml-base-instruction'
 require_relative 'tc-yaml-collection-instruction'
 require_relative 'tc-yaml-configuration-parser'
+require_relative 'tc-yaml-publish-instruction'
 


### PR DESCRIPTION
It's now possible to add port forwardings using the `publish` instruction, e.g.:

````yaml
---
base: ubuntu:16.04
install:
 - apache2
publish:
 - 8080:80
---
````

All current [publication formats](https://docs.docker.com/engine/reference/run/#expose-incoming-ports) of docker are supported.