### PR TITLE
Fix archlinux image and add more tests

### DIFF
--- a/src/docker/arch.rb
+++ b/src/docker/arch.rb
@@ -31,7 +31,7 @@ require_relative 'dockerfile'
 class ArchDockerContext < BaseDockerContext
 
 	# @param id {@link Id}-like object
-	# @param from Docker image to be used as base (e.g. `archlinux/base')
+	# @param from Docker image to be used as base (e.g. `archlinux:base')
 	def initialize(id, from)
 		uid = id.user_id
 		gid = id.group_id

--- a/src/docker/factory.rb
+++ b/src/docker/factory.rb
@@ -30,7 +30,7 @@ require_relative 'ubuntu'
 # Provides a factory for creating {@link BaseDockerContext} instances from
 # specification
 #
-#  a) `archlinux/…' → {@link ArchDockerContext}
+#  a) `archlinux:…' → {@link ArchDockerContext}
 #  b) `debian:…' → {@link DebianDockerContext}
 #  c) `fedora:…' → {@link FedoraDockerContext}
 #  d) `ubuntu:…' → {@link UbuntuDockerContext}
@@ -50,7 +50,7 @@ class DockerContextFactory
 
 	def from_specification(specification)
 
-		if specification.start_with? 'archlinux/'
+		if specification.start_with? 'archlinux:'
 			return ArchDockerContext.new @id, specification
 
 		elsif specification.start_with? 'debian:'

--- a/test/tc-docker-arch.rb
+++ b/test/tc-docker-arch.rb
@@ -76,7 +76,7 @@ class TestArchDockerContext < Test::Unit::TestCase
 
 
 	def test_Arch_Base
-		self.execute_smoke_test 'archlinux/base'
+		self.execute_smoke_test 'archlinux:base'
 	end
 end
 

--- a/test/tc-docker-debian.rb
+++ b/test/tc-docker-debian.rb
@@ -86,6 +86,5 @@ class TestDebianDockerContext < Test::Unit::TestCase
 	def test_Debian_Buster
 		self.execute_smoke_test 'debian:buster'
 	end
-
 end
 

--- a/test/tc-docker-factory.rb
+++ b/test/tc-docker-factory.rb
@@ -34,8 +34,8 @@ class TestDockerContextFactory < Test::Unit::TestCase
 
 	def test_Arch
 		factory = DockerContextFactory.new Id.real
-		arch = factory.from_specification 'archlinux/base'
-		assert(arch.kind_of?(ArchDockerContext), '`archlinux/base\' should have led to ArchDockerContext')
+		arch = factory.from_specification 'archlinux:base'
+		assert(arch.kind_of?(ArchDockerContext), '`archlinux:base\' should have led to ArchDockerContext')
 	end
 
 

--- a/test/tc-docker-fedora.rb
+++ b/test/tc-docker-fedora.rb
@@ -113,6 +113,14 @@ class TestFedoraDockerContext < Test::Unit::TestCase
 		self.execute_smoke_test 'fedora:32'
 	end
 
+	def test_Fedora_33
+		self.execute_smoke_test 'fedora:33'
+	end
+
+	def test_Fedora_34
+		self.execute_smoke_test 'fedora:34'
+	end
+
 	def test_Fedora_Rawhide
 		self.execute_smoke_test 'fedora:rawhide'
 	end

--- a/test/tc-docker-ubuntu.rb
+++ b/test/tc-docker-ubuntu.rb
@@ -91,5 +91,12 @@ class TestUbuntuDockerContext < Test::Unit::TestCase
 		self.execute_smoke_test 'ubuntu:20.04'
 	end
 
+	def test_Ubuntu_2010
+		self.execute_smoke_test 'ubuntu:20.10'
+	end
+
+	def test_Ubuntu_2104
+		self.execute_smoke_test 'ubuntu:21.04'
+	end
 end
 


### PR DESCRIPTION
The syntax `archlinux/base` no longer works and had to be replaced by `archlinux:base`. Moreover a couple of up to date images were added to ensure mini-cross works with those distributions.