### PR TITLE
Replace debian strech with bullseye to fix  CI build task

### DIFF
--- a/test/tc-docker-debian.rb
+++ b/test/tc-docker-debian.rb
@@ -75,12 +75,12 @@ class TestDebianDockerContext < Test::Unit::TestCase
 
 
 
-	def test_Debian_Stretch
-		self.execute_smoke_test 'debian:stretch'
-	end
-
 	def test_Debian_Buster
 		self.execute_smoke_test 'debian:buster'
+	end
+
+	def test_Debian_Bullseye
+		self.execute_smoke_test 'debian:bullseye'
 	end
 end
 


### PR DESCRIPTION
The debian strech image is currently broken, cause the repos are not reachable anymore.

Replaced with bullseye (Debian 11), because it was missing.

Should fix pullrequest CI #25 and #24