### PR TITLE
Set debconf noninteractive frontend for Debian

### DIFF
--- a/src/docker/debian.rb
+++ b/src/docker/debian.rb
@@ -55,6 +55,17 @@ class DebianDockerContext < BaseDockerContext
 		df.run_sh	'apt-get -y update && apt-get -y install sudo'
 		df.run_sh	"echo 'ALL            ALL = (ALL) NOPASSWD: ALL' >> /etc/sudoers"
 
+		# Installing certain packages is causing a prompt during package
+		# installation and will in turn block, even when employing
+		# {@code DEBIAN_FRONTEND=noninteractive}.
+		#
+		# Because of this we are forced to globally set non interactive
+		# frontend which will persist even into the container runtime.
+		#
+		# @see https://github.com/moby/moby/issues/27988#issuecomment-600831315
+		df.run_sh	'apt-get -y update && apt-get -y install debconf'
+		df.run_sh       "echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections"
+
 		# Add user in context similar to host user
 		df.run_exec	['groupadd', '--gid', gid, group]
 		df.run_exec	['useradd', '--gid', gid, '--uid', uid, '--home', "/home/#{user}", user]


### PR DESCRIPTION
## Summary

The Ubuntu context sets the debconf frontend to Noninteractive via `debconf-set-selections`, but the Debian context does not. This causes noisy debconf warnings during `docker build` when packages are installed via the `install:` YAML key:

```
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC ...)
debconf: falling back to frontend: Teletype
debconf: unable to initialize frontend: Teletype
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Noninteractive
```

This applies the same `debconf-set-selections` fix from `UbuntuDockerContext` to `DebianDockerContext`.